### PR TITLE
Add Linguist Override

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Overriding Rebol classification
-*.[R$|r$] linguist-language=R
+*.(R|r)$ linguist-language=R

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Overriding Rebol classification
-*.R linguist-language=R
+*.[R$|r$] linguist-language=R

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Overriding Rebol classification
+*.R linguist-language=R


### PR DESCRIPTION
This is to try and fix the problem with tests/testthat/test-qtr.R having the incorrect colours. GitHub is mislabelling the file as a Rebol file rather than an R file so it's colouring it as it would a Rebol file. Apparently this is a common issue that used to happen a lot because Rebol used to use the file extension .r. I think there is a better way to fix it, but for now a workaround is creating an attributes file to force the language classifier (linguist) to class .r/R files as R rather than Rebol. 

For the record, I'm not actually sure this will work. I forked the repo and merged it on my fork to see and it looks like it is flicking back and forth, so this may have been a pointless exercise. It's also not that important, but it has been annoying me so I would like to fix it. 