### PR TITLE
Jack

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: phsmethods
 Title: Standard Methods for use in Public Health Scotland
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(
     person("Jack", "Hannah", email = "jack.hannah1@nhs.net", role = c("aut", "cre")),
     person("David", "Caldwell", email = "david.caldwell1@nhs.net", role = c("aut", "rev")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
-# phsmethods 0.1.0
+# phsmethods 0.1.1 (2020-01-29)
+- `file_size()`, `fin_year()`, `qtr()`, `qtr_end()`, `qtr_next()` and `qtr_prev()` now use `inherits(x, y)` as opposed to `class(x) == y` to check class. The reasoning is explained in this [blogpost by Martin Maechler](https://developer.r-project.org/Blog/public/2019/11/09/when-you-think-class.-think-again/index.html). 
 
-- Initial package release
-- `file_size`, `fin_year`, `postcode`, `qtr`, `qtr_end`, `qtr_next` and `qtr_prev` functions added
+# phsmethods 0.1.0 (2020-01-24)
+
+- Initial package release.
+- `file_size()`, `fin_year()`, `postcode()`, `qtr()`, `qtr_end()`, `qtr_next()` and `qtr_prev()` functions added.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 # phsmethods 0.1.1 (2020-01-29)
-- `file_size()`, `fin_year()`, `qtr()`, `qtr_end()`, `qtr_next()` and `qtr_prev()` now use `inherits(x, y)` as opposed to `class(x) == y` to check class. The reasoning is explained in this [blogpost by Martin Maechler](https://developer.r-project.org/Blog/public/2019/11/09/when-you-think-class.-think-again/index.html). 
+- `file_size()`, `fin_year()`, `qtr()`, `qtr_end()`, `qtr_next()` and `qtr_prev()` now use `inherits(x, "y")` instead of `class(x) == "y"` to check class. The reasoning is explained in this [blogpost by Martin Maechler](https://developer.r-project.org/Blog/public/2019/11/09/when-you-think-class.-think-again/index.html). 
 
 # phsmethods 0.1.0 (2020-01-24)
 

--- a/R/file_size.R
+++ b/R/file_size.R
@@ -79,14 +79,14 @@ file_size <- function(filepath = getwd(), pattern = NULL) {
     stop("A valid filepath must be supplied")
   }
 
-  if (!class(pattern) %in% c("character", "NULL")) {
+  if (!inherits(pattern, c("character", "NULL"))) {
     stop("A specified pattern must be of character class in order to be ",
          "evaluated as a regular expression")
   }
 
   x <- dir(path = filepath, pattern = pattern)
 
-  if(length(x) == 0) {
+  if (length(x) == 0) {
     return(NULL)
   }
 

--- a/R/fin_year.R
+++ b/R/fin_year.R
@@ -15,10 +15,12 @@
 #' fin_year(x)
 #'
 #' @export
-fin_year <- function(date){
-  if(class(date) != "Date"){
+fin_year <- function(date) {
+
+  if (!inherits(date, "Date")) {
     stop("The input must have Date class.")
   }
+
   paste0(ifelse(lubridate::month(date) >= 4,
                 lubridate::year(date),
                 lubridate::year(date) - 1), "/",

--- a/R/phsmethods.R
+++ b/R/phsmethods.R
@@ -11,4 +11,4 @@ NULL
 
 # Stops notes from appearing in R CMD check because of undefined global
 # variable '.'
-if(getRversion() >= "2.15.1")  utils::globalVariables(c("."))
+if (getRversion() >= "2.15.1")  utils::globalVariables(c("."))

--- a/R/postcode.R
+++ b/R/postcode.R
@@ -84,10 +84,11 @@ postcode <- function(string, format = c("pc7", "pc8")) {
   singular <- "value does"
   multiple <- "values do"
 
-  if(!all(
-    stringr::str_detect(
-      pc[!is.na(pc)],
-      "^[A-Za-z]{1,2}[0-9][A-Za-z0-9]?[0-9]{1}[A-Za-z]{2}$"))) {
+  if (
+    !all(
+      stringr::str_detect(
+        pc[!is.na(pc)],
+        "^[A-Za-z]{1,2}[0-9][A-Za-z0-9]?[0-9]{1}[A-Za-z]{2}$"))) {
     warning(glue::glue("{n} non-NA input {ifelse(n == 1, singular, multiple)} ",
                        "not adhere to the standard UK postcode format (with ",
                        "or without spaces) and will be coded as NA. The ",
@@ -107,7 +108,7 @@ postcode <- function(string, format = c("pc7", "pc8")) {
                   "^[A-Za-z]{1,2}[0-9][A-Za-z0-9]?[0-9]{1}[A-Za-z]{2}$"),
                 NA_character_)
 
-  if(any(grepl("[a-z]", pc))) {
+  if (any(grepl("[a-z]", pc))) {
     warning("Lower case letters in any input value(s) adhering to the ",
             "standard UK postcode format will be converted to upper case")
   }

--- a/R/qtr.R
+++ b/R/qtr.R
@@ -155,8 +155,8 @@ qtr_prev <- function(date, format = c("long", "short")) {
 
   format <- match.arg(format)
 
-  if (class(date) != "Date") {
-    stop("The input must have Date class")
+  if (!inherits(date, "Date")) {
+    stop("The input must have Date class.")
   }
 
   quarter_num <- lubridate::quarter(date)

--- a/R/qtr.R
+++ b/R/qtr.R
@@ -47,8 +47,8 @@ qtr <- function(date, format = c("long", "short")) {
 
   format <- match.arg(format)
 
-  if (class(date) != "Date") {
-    stop("The input must have Date class")
+  if (!inherits(date, "Date")) {
+    stop("The input must have Date class.")
   }
 
   quarter_num <- lubridate::quarter(date)
@@ -64,6 +64,7 @@ qtr <- function(date, format = c("long", "short")) {
       quarter_num == 4 ~ paste0("October to December ",
                                 lubridate::year(date))))
   } else {
+
     return(dplyr::case_when(
       quarter_num == 1 ~ paste0("Jan-Mar ",
                                 lubridate::year(date)),
@@ -82,8 +83,8 @@ qtr_end <- function(date, format = c("long", "short")) {
 
   format <- match.arg(format)
 
-  if (class(date) != "Date") {
-    stop("The input must have Date class")
+  if (!inherits(date, "Date")) {
+    stop("The input must have Date class.")
   }
 
   quarter_num <- lubridate::quarter(date)
@@ -99,6 +100,7 @@ qtr_end <- function(date, format = c("long", "short")) {
       quarter_num == 4 ~ paste0("December ",
                                 lubridate::year(date))))
   } else {
+
     return(dplyr::case_when(
       quarter_num == 1 ~ paste0("Mar ",
                                 lubridate::year(date)),
@@ -117,8 +119,8 @@ qtr_next <- function(date, format = c("long", "short")) {
 
   format <- match.arg(format)
 
-  if (class(date) != "Date") {
-    stop("The input must have Date class")
+  if (!inherits(date, "Date")) {
+    stop("The input must have Date class.")
   }
 
   quarter_num <- lubridate::quarter(date)
@@ -134,6 +136,7 @@ qtr_next <- function(date, format = c("long", "short")) {
       quarter_num == 4 ~ paste0("January to March ",
                                 lubridate::year(date) + 1)))
   } else {
+
     return(dplyr::case_when(
       quarter_num == 1 ~ paste0("Apr-Jun ",
                                 lubridate::year(date)),
@@ -169,6 +172,7 @@ qtr_prev <- function(date, format = c("long", "short")) {
       quarter_num == 4 ~ paste0("July to September ",
                                 lubridate::year(date))))
   } else {
+
     return(dplyr::case_when(
       quarter_num == 1 ~ paste0("Oct-Dec ",
                                 lubridate::year(date) - 1),

--- a/README.Rmd
+++ b/README.Rmd
@@ -24,7 +24,7 @@ knitr::opts_chunk$set(
 - `postcode()` formats improperly recorded postcodes
 - `qtr()`, `qtr_end()`, `qtr_next()` and `qtr_prev()` assign a date to a quarter
 
-`phsmethods` can be used on both the [server](http://spsssrv02.csa.scot.nhs.uk:8787/) and desktop versions of RStudio.
+`phsmethods` can be used on both the [server](https://rstudio.nhsnss.scot.nhs.uk/) and desktop versions of RStudio.
 
 ## Installation
 
@@ -126,7 +126,7 @@ This package is intended to be in continuous development and contributions may b
 
 When contributing, please create a [branch](https://github.com/Health-SocialCare-Scotland/phsmethods/branches) in this repository and carry out all work on it. Please ensure you have linked RStudio to your GitHub account using `usethis::edit_git_config()` prior to making your contribution. When you are ready for a review, please create a [pull request](https://github.com/Health-SocialCare-Scotland/phsmethods/pulls) and assign **all** of the package maintainers as reviewers. One or more of them will conduct a review, provide feedback and, if necessary, request changes prior to merging your branch.
 
-Please be mindful of information governance when contributing to this package. No data files (aside from publically available and downloadable datasets or unless explicitly approved), server connection details, passwords or person identifiable or otherwise confidential information should be included anywhere within this package or any other repository (whether public or private) used within PHS. This includes within code and code commentary. For more information on security when using git and GitHub, and on using git and GitHub for version control more generally, please see the [Transforming Publishing Programme](https://www.isdscotland.org/Products-and-Services/Transforming-Publishing-Programme/)'s [Git guide](https://nhs-nss-transforming-publications.github.io/git-guide/) and [GitHub guidance](https://github.com/NHS-NSS-transforming-publications/GitHub-guidance).
+Please be mindful of information governance when contributing to this package. No data files (aside from publicly available and downloadable datasets or unless explicitly approved), server connection details, passwords or person identifiable or otherwise confidential information should be included anywhere within this package or any other repository (whether public or private) used within PHS. This includes within code and code commentary. For more information on security when using git and GitHub, and on using git and GitHub for version control more generally, please see the [Transforming Publishing Programme](https://www.isdscotland.org/Products-and-Services/Transforming-Publishing-Programme/)'s [Git guide](https://nhs-nss-transforming-publications.github.io/git-guide/) and [GitHub guidance](https://github.com/NHS-NSS-transforming-publications/GitHub-guidance).
 
 Please feel free to add yourself to the 'Authors' section of the `Description` file when contributing. As a rule of thumb, please assign your role as author (`"aut"`) when writing an exported function, and as contributor (`"ctb"`) when editing an existing function and/or writing a non-exported function.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ phsmethods
 -   `postcode()` formats improperly recorded postcodes
 -   `qtr()`, `qtr_end()`, `qtr_next()` and `qtr_prev()` assign a date to a quarter
 
-`phsmethods` can be used on both the [server](http://spsssrv02.csa.scot.nhs.uk:8787/) and desktop versions of RStudio.
+`phsmethods` can be used on both the [server](https://rstudio.nhsnss.scot.nhs.uk/) and desktop versions of RStudio.
 
 Installation
 ------------
@@ -154,7 +154,7 @@ This package is intended to be in continuous development and contributions may b
 
 When contributing, please create a [branch](https://github.com/Health-SocialCare-Scotland/phsmethods/branches) in this repository and carry out all work on it. Please ensure you have linked RStudio to your GitHub account using `usethis::edit_git_config()` prior to making your contribution. When you are ready for a review, please create a [pull request](https://github.com/Health-SocialCare-Scotland/phsmethods/pulls) and assign **all** of the package maintainers as reviewers. One or more of them will conduct a review, provide feedback and, if necessary, request changes prior to merging your branch.
 
-Please be mindful of information governance when contributing to this package. No data files (aside from publically available and downloadable datasets or unless explicitly approved), server connection details, passwords or person identifiable or otherwise confidential information should be included anywhere within this package or any other repository (whether public or private) used within PHS. This includes within code and code commentary. For more information on security when using git and GitHub, and on using git and GitHub for version control more generally, please see the [Transforming Publishing Programme](https://www.isdscotland.org/Products-and-Services/Transforming-Publishing-Programme/)'s [Git guide](https://nhs-nss-transforming-publications.github.io/git-guide/) and [GitHub guidance](https://github.com/NHS-NSS-transforming-publications/GitHub-guidance).
+Please be mindful of information governance when contributing to this package. No data files (aside from publicly available and downloadable datasets or unless explicitly approved), server connection details, passwords or person identifiable or otherwise confidential information should be included anywhere within this package or any other repository (whether public or private) used within PHS. This includes within code and code commentary. For more information on security when using git and GitHub, and on using git and GitHub for version control more generally, please see the [Transforming Publishing Programme](https://www.isdscotland.org/Products-and-Services/Transforming-Publishing-Programme/)'s [Git guide](https://nhs-nss-transforming-publications.github.io/git-guide/) and [GitHub guidance](https://github.com/NHS-NSS-transforming-publications/GitHub-guidance).
 
 Please feel free to add yourself to the 'Authors' section of the `Description` file when contributing. As a rule of thumb, please assign your role as author (`"aut"`) when writing an exported function, and as contributor (`"ctb"`) when editing an existing function and/or writing a non-exported function.
 


### PR DESCRIPTION
Most of these changes are spacing and typos. The main change (and the one justifying updating to version `0.1.1`) is changing any test along the lines

`if (class(x != "y")) error` to

`if(!inherits(x, "y")) error`

so as to better deal with situations like this:

```r
data(airquality); class(tibble::as_tibble(airquality))
#> [1] "tbl_df"     "tbl"        "data.frame"

class(tibble::as_tibble(airquality)) == "tbl"
#> [1] FALSE  TRUE FALSE

inherits(tibble::as_tibble(airquality), "tbl")
#> [1] TRUE
```

Let me know if you spot any more typos and I'll do another release once it's been merged.