### PR TITLE
Open data fmt

### DIFF
--- a/R/qtr.R
+++ b/R/qtr.R
@@ -10,6 +10,8 @@
 #' \item \code{qtr} returns the current quarter.
 #'
 #' \item \code{qtr_end} returns the last month in the quarter.
+#' 
+#' \item \code{qtr_start} returns the first month in the quarter.
 #'
 #' \item \code{qtr_next} returns the next quarter.
 #'
@@ -19,10 +21,10 @@
 #' @details Quarters are defined as:
 #'
 #' \itemize{
-#' \item January to March (Jan-Mar)
-#' \item April to June (Apr-Jun)
-#' \item July to September (Jul-Sep)
-#' \item October to December (Oct-Dec)
+#' \item January to March (Jan-Mar, Q1)
+#' \item April to June (Apr-Jun, Q2)
+#' \item July to September (Jul-Sep, Q3)
+#' \item October to December (Oct-Dec, Q4)
 #' }
 #'
 #' @param date A date supplied with \code{Date} class.
@@ -124,6 +126,49 @@ qtr_end <- function(date, format = c("long", "short", "open")) {
 
 #' @export
 #' @rdname qtr
+qtr_start <- function(date, format = c("long", "short", "open")) {
+  
+  format <- match.arg(format)
+  
+  if (!inherits(date, "Date")) {
+    stop("The input must have Date class.")
+  }
+  
+  quarter_num <- lubridate::quarter(date)
+  
+  if (format == "long") {
+    return(dplyr::case_when(
+      quarter_num == 1 ~ paste0("January ",
+                                lubridate::year(date)),
+      quarter_num == 2 ~ paste0("April ",
+                                lubridate::year(date)),
+      quarter_num == 3 ~ paste0("July ",
+                                lubridate::year(date)),
+      quarter_num == 4 ~ paste0("October ",
+                                lubridate::year(date))))
+  }
+  else if(format == "open"){
+    return(dplyr::case_when(
+      quarter_num == 1 ~ paste0(lubridate::year(date), "01"),
+      quarter_num == 2 ~ paste0(lubridate::year(date), "04"),
+      quarter_num == 3 ~ paste0(lubridate::year(date), "07"),
+      quarter_num == 4 ~ paste0(lubridate::year(date), "10")))
+  } else{
+    
+    return(dplyr::case_when(
+      quarter_num == 1 ~ paste0("Jan ",
+                                lubridate::year(date)),
+      quarter_num == 2 ~ paste0("Apr ",
+                                lubridate::year(date)),
+      quarter_num == 3 ~ paste0("Jul ",
+                                lubridate::year(date)),
+      quarter_num == 4 ~ paste0("Oct ",
+                                lubridate::year(date))))
+  }
+}
+
+#' @export
+#' @rdname qtr
 qtr_next <- function(date, format = c("long", "short", "open")) {
   
   format <- match.arg(format)
@@ -207,5 +252,3 @@ qtr_prev <- function(date, format = c("long", "short", "open")) {
                                 lubridate::year(date))))
   } 
 }
-
-

--- a/R/qtr.R
+++ b/R/qtr.R
@@ -44,15 +44,15 @@
 #' @export
 #' @rdname qtr
 qtr <- function(date, format = c("long", "short", "open")) {
-
+  
   format <- match.arg(format)
-
+  
   if (!inherits(date, "Date")) {
     stop("The input must have Date class.")
   }
-
+  
   quarter_num <- lubridate::quarter(date)
-
+  
   if (format == "long") {
     return(dplyr::case_when(
       quarter_num == 1 ~ paste0("January to March ",
@@ -63,8 +63,10 @@ qtr <- function(date, format = c("long", "short", "open")) {
                                 lubridate::year(date)),
       quarter_num == 4 ~ paste0("October to December ",
                                 lubridate::year(date))))
-  } else if(format == "short"){
-
+  } else if(format == "open"){
+    return(paste0(lubridate::year(date), "Q", quarter_num))
+  } else{
+    
     return(dplyr::case_when(
       quarter_num == 1 ~ paste0("Jan-Mar ",
                                 lubridate::year(date)),
@@ -74,14 +76,7 @@ qtr <- function(date, format = c("long", "short", "open")) {
                                 lubridate::year(date)),
       quarter_num == 4 ~ paste0("Oct-Dec ",
                                 lubridate::year(date))))
-  }
-  else if(format == "open"){
-    return(paste0(lubridate::year(date), "Q", quarter_num))
-  }
-  else{
-    print("Incorect `format` option: try, `long`, `short`, `open`.")
-    return(NA)
-  }
+  } 
 }
 
 #' @export
@@ -130,15 +125,15 @@ qtr_end <- function(date, format = c("long", "short", "open")) {
 #' @export
 #' @rdname qtr
 qtr_next <- function(date, format = c("long", "short", "open")) {
-
+  
   format <- match.arg(format)
-
+  
   if (!inherits(date, "Date")) {
     stop("The input must have Date class.")
   }
-
+  
   quarter_num <- lubridate::quarter(date)
-
+  
   if (format == "long") {
     return(dplyr::case_when(
       quarter_num == 1 ~ paste0("April to June ",
@@ -149,8 +144,16 @@ qtr_next <- function(date, format = c("long", "short", "open")) {
                                 lubridate::year(date)),
       quarter_num == 4 ~ paste0("January to March ",
                                 lubridate::year(date) + 1)))
-  } else if(format == "short"){
-
+  } else if(format == "open"){
+    if(quarter_num == 4){
+      return(paste0(lubridate::year(date) + 1, "Q1"))
+    }
+    else{
+      return(paste0(lubridate::year(date), "Q", as.character(quarter_num + 1)))  
+    }
+    # return(dplyr::if_else(quarter_num == 4, paste0(lubridate::year(date), "Q", 1), paste0(lubridate::year(date), "Q", quarter_num + 1))
+  } else{
+    
     return(dplyr::case_when(
       quarter_num == 1 ~ paste0("Apr-Jun ",
                                 lubridate::year(date)),
@@ -161,27 +164,20 @@ qtr_next <- function(date, format = c("long", "short", "open")) {
       quarter_num == 4 ~ paste0("Jan-Mar ",
                                 lubridate::year(date) + 1)))
   }
-  else if(format == "open"){
-    return(paste0(lubridate::year(date), "Q", quarter_num))
-  }
-  else{
-    print("Incorect `format` option: try, `long`, `short`, `open`.")
-    return(NA)
-  }
 }
 
 #' @export
 #' @rdname qtr
 qtr_prev <- function(date, format = c("long", "short", "open")) {
-
+  
   format <- match.arg(format)
-
+  
   if (!inherits(date, "Date")) {
     stop("The input must have Date class.")
   }
-
+  
   quarter_num <- lubridate::quarter(date)
-
+  
   if (format == "long") {
     return(dplyr::case_when(
       quarter_num == 1 ~ paste0("October to December ",
@@ -192,8 +188,14 @@ qtr_prev <- function(date, format = c("long", "short", "open")) {
                                 lubridate::year(date)),
       quarter_num == 4 ~ paste0("July to September ",
                                 lubridate::year(date))))
-  } else if(format == "short"){
-
+  } else if(format == "open"){
+      if(quarter_num == 1){
+        return(paste0(lubridate::year(date) - 1, "Q4"))
+      } else{
+        return(paste0(lubridate::year(date), as.character(quarter_num - 1)))
+      }
+  } else{
+    
     return(dplyr::case_when(
       quarter_num == 1 ~ paste0("Oct-Dec ",
                                 lubridate::year(date) - 1),
@@ -203,13 +205,6 @@ qtr_prev <- function(date, format = c("long", "short", "open")) {
                                 lubridate::year(date)),
       quarter_num == 4 ~ paste0("Jul-Sep ",
                                 lubridate::year(date))))
-  }
-  else if(format == "open"){
-    return(paste0(lubridate::year(date), "Q", quarter_num))
-  }
-  else{
-    print("Incorect `format` option: try, `long`, `short`, `open`.")
-    return(NA)
-  }
+  } 
 }
 

--- a/R/qtr.R
+++ b/R/qtr.R
@@ -43,7 +43,7 @@
 
 #' @export
 #' @rdname qtr
-qtr <- function(date, format = c("long", "short")) {
+qtr <- function(date, format = c("long", "short", "open")) {
 
   format <- match.arg(format)
 
@@ -63,7 +63,7 @@ qtr <- function(date, format = c("long", "short")) {
                                 lubridate::year(date)),
       quarter_num == 4 ~ paste0("October to December ",
                                 lubridate::year(date))))
-  } else {
+  } else if(format == "short"){
 
     return(dplyr::case_when(
       quarter_num == 1 ~ paste0("Jan-Mar ",
@@ -75,11 +75,18 @@ qtr <- function(date, format = c("long", "short")) {
       quarter_num == 4 ~ paste0("Oct-Dec ",
                                 lubridate::year(date))))
   }
+  else if(format == "open"){
+    return(paste0(lubridate::year(date), "Q", quarter_num))
+  }
+  else{
+    print("Incorect `format` option: try, `long`, `short`, `open`.")
+    return(NA)
+  }
 }
 
 #' @export
 #' @rdname qtr
-qtr_end <- function(date, format = c("long", "short")) {
+qtr_end <- function(date, format = c("long", "short", "open")) {
 
   format <- match.arg(format)
 
@@ -99,7 +106,7 @@ qtr_end <- function(date, format = c("long", "short")) {
                                 lubridate::year(date)),
       quarter_num == 4 ~ paste0("December ",
                                 lubridate::year(date))))
-  } else {
+  } else if(format == "short") {
 
     return(dplyr::case_when(
       quarter_num == 1 ~ paste0("Mar ",
@@ -111,11 +118,18 @@ qtr_end <- function(date, format = c("long", "short")) {
       quarter_num == 4 ~ paste0("Dec ",
                                 lubridate::year(date))))
   }
+  else if(format == "open"){
+    return(paste0(lubridate::year(date), "Q", quarter_num))
+  }
+  else{
+    print("Incorect `format` option: try, `long`, `short`, `open`.")
+    return(NA)
+  }
 }
 
 #' @export
 #' @rdname qtr
-qtr_next <- function(date, format = c("long", "short")) {
+qtr_next <- function(date, format = c("long", "short", "open")) {
 
   format <- match.arg(format)
 
@@ -135,7 +149,7 @@ qtr_next <- function(date, format = c("long", "short")) {
                                 lubridate::year(date)),
       quarter_num == 4 ~ paste0("January to March ",
                                 lubridate::year(date) + 1)))
-  } else {
+  } else if(format == "short"){
 
     return(dplyr::case_when(
       quarter_num == 1 ~ paste0("Apr-Jun ",
@@ -147,11 +161,18 @@ qtr_next <- function(date, format = c("long", "short")) {
       quarter_num == 4 ~ paste0("Jan-Mar ",
                                 lubridate::year(date) + 1)))
   }
+  else if(format == "open"){
+    return(paste0(lubridate::year(date), "Q", quarter_num))
+  }
+  else{
+    print("Incorect `format` option: try, `long`, `short`, `open`.")
+    return(NA)
+  }
 }
 
 #' @export
 #' @rdname qtr
-qtr_prev <- function(date, format = c("long", "short")) {
+qtr_prev <- function(date, format = c("long", "short", "open")) {
 
   format <- match.arg(format)
 
@@ -171,7 +192,7 @@ qtr_prev <- function(date, format = c("long", "short")) {
                                 lubridate::year(date)),
       quarter_num == 4 ~ paste0("July to September ",
                                 lubridate::year(date))))
-  } else {
+  } else if(format == "short"){
 
     return(dplyr::case_when(
       quarter_num == 1 ~ paste0("Oct-Dec ",
@@ -183,4 +204,12 @@ qtr_prev <- function(date, format = c("long", "short")) {
       quarter_num == 4 ~ paste0("Jul-Sep ",
                                 lubridate::year(date))))
   }
+  else if(format == "open"){
+    return(paste0(lubridate::year(date), "Q", quarter_num))
+  }
+  else{
+    print("Incorect `format` option: try, `long`, `short`, `open`.")
+    return(NA)
+  }
 }
+

--- a/R/qtr.R
+++ b/R/qtr.R
@@ -82,15 +82,15 @@ qtr <- function(date, format = c("long", "short", "open")) {
 #' @export
 #' @rdname qtr
 qtr_end <- function(date, format = c("long", "short", "open")) {
-
+  
   format <- match.arg(format)
-
+  
   if (!inherits(date, "Date")) {
     stop("The input must have Date class.")
   }
-
+  
   quarter_num <- lubridate::quarter(date)
-
+  
   if (format == "long") {
     return(dplyr::case_when(
       quarter_num == 1 ~ paste0("March ",
@@ -101,8 +101,15 @@ qtr_end <- function(date, format = c("long", "short", "open")) {
                                 lubridate::year(date)),
       quarter_num == 4 ~ paste0("December ",
                                 lubridate::year(date))))
-  } else if(format == "short") {
-
+  }
+  else if(format == "open"){
+    return(dplyr::case_when(
+      quarter_num == 1 ~ paste0(lubridate::year(date), "03"),
+      quarter_num == 2 ~ paste0(lubridate::year(date), "06"),
+      quarter_num == 3 ~ paste0(lubridate::year(date), "09"),
+      quarter_num == 4 ~ paste0(lubridate::year(date), "12")))
+  } else{
+    
     return(dplyr::case_when(
       quarter_num == 1 ~ paste0("Mar ",
                                 lubridate::year(date)),
@@ -112,13 +119,6 @@ qtr_end <- function(date, format = c("long", "short", "open")) {
                                 lubridate::year(date)),
       quarter_num == 4 ~ paste0("Dec ",
                                 lubridate::year(date))))
-  }
-  else if(format == "open"){
-    return(paste0(lubridate::year(date), "Q", quarter_num))
-  }
-  else{
-    print("Incorect `format` option: try, `long`, `short`, `open`.")
-    return(NA)
   }
 }
 
@@ -189,11 +189,11 @@ qtr_prev <- function(date, format = c("long", "short", "open")) {
       quarter_num == 4 ~ paste0("July to September ",
                                 lubridate::year(date))))
   } else if(format == "open"){
-      if(quarter_num == 1){
-        return(paste0(lubridate::year(date) - 1, "Q4"))
-      } else{
-        return(paste0(lubridate::year(date), as.character(quarter_num - 1)))
-      }
+    if(quarter_num == 1){
+      return(paste0(lubridate::year(date) - 1, "Q4"))
+    } else{
+      return(paste0(lubridate::year(date), "Q", as.character(quarter_num - 1)))
+    }
   } else{
     
     return(dplyr::case_when(
@@ -207,4 +207,5 @@ qtr_prev <- function(date, format = c("long", "short", "open")) {
                                 lubridate::year(date))))
   } 
 }
+
 


### PR DESCRIPTION
Open data dates are rrequired to be in a specific format. For quarters this is <yyyyQn> e.g. 2019Q3. Or when month numbers have to be <yyyymm>. I have updated qtr to allow for the option of "open" for open data formats. I have also added a qtr_start function similar to qtr_end. 

I haven't done any documentation previously, I have updated the top where it seemed appropreate but not 100% sure.