### PR TITLE
Make chi_pad() more strict

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,4 +34,4 @@ Suggests:
     testthat (>= 2.0.0)
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0

--- a/R/chi.R
+++ b/R/chi.R
@@ -112,7 +112,7 @@ sub_num <- function(x, num) {
 #'
 #' @description \code{chi_pad} takes a nine-digit CHI number with
 #' \code{character} class and prefixes it with a zero. Any values provided
-#' which are not nine characters in length remain unchanged.
+#' which are not a string comprised of nine numeric digits remain unchanged.
 #'
 #' @details The Community Health Index (CHI) is a register of all patients in
 #' NHS Scotland. A CHI number is a unique, ten-digit identifier assigned to

--- a/R/chi.R
+++ b/R/chi.R
@@ -144,7 +144,7 @@ chi_pad <- function(x) {
   }
 
   # Add a leading zero to any string comprised of nine numeric digits
-  ifelse(stringr::str_detect(x, "^[1-9]{9}$"),
+  ifelse(stringr::str_detect(x, "^[0-9]{9}$"),
          paste0("0", x),
          x)
 }

--- a/R/chi.R
+++ b/R/chi.R
@@ -143,8 +143,8 @@ chi_pad <- function(x) {
     stop("The input must be of character class")
   }
 
-  # Add a leading zero to any nine character CHI numbers
-  ifelse(nchar(x) == 9,
+  # Add a leading zero to any string comprised of nine numeric digits
+  ifelse(stringr::str_detect(x, "^[1-9]{9}$"),
          paste0("0", x),
          x)
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -88,8 +88,8 @@ b %>% mutate(validity = chi_check(chi))
 ### chi_pad
 
 ```{r chi_pad}
-# Only nine-digit characters are prefixed with a zero
-chi_pad(c("101011237", "101201234", "123223"))
+# Only nine-digit characters comprised exclusively of numeric digits are prefixed with a zero
+chi_pad(c("101011237", "101201234", "123223", "abcdefghi", "12345tuvw"))
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ working on RStudio desktop. If this is the case, `phsmethods` can be
 installed by downloading the [zip of the
 repository](https://github.com/Health-SocialCare-Scotland/phsmethods/archive/master.zip)
 and running the following code (replacing the section marked `<>`,
-including the arrows themselves):
+including the arrows
+themselves):
 
 ``` r
 remotes::install_local("<FILEPATH OF ZIPPED FILE>/phsmethods-master.zip",
@@ -102,9 +103,9 @@ b %>% mutate(validity = chi_check(chi))
 ### chi\_pad
 
 ``` r
-# Only nine-digit characters are prefixed with a zero
-chi_pad(c("101011237", "101201234", "123223"))
-#> [1] "0101011237" "0101201234" "123223"
+# Only nine-digit characters comprised exclusively of numeric digits are prefixed with a zero
+chi_pad(c("101011237", "101201234", "123223", "abcdefghi", "12345tuvw"))
+#> [1] "0101011237" "0101201234" "123223"     "abcdefghi"  "12345tuvw"
 ```
 
 ### file\_size
@@ -120,7 +121,7 @@ file_size(testthat::test_path("files"))
 #> 3 iris.csv         CSV 4 KB   
 #> 4 mtcars.sav       SPSS 4 KB  
 #> 5 plant-growth.rds RDS 316 B  
-#> 6 puromycin.txt    Text 442 B 
+#> 6 puromycin.txt    Text 418 B 
 #> 7 stackloss.fst    FST 897 B  
 #> 8 swiss.tsv        TSV 1 KB
 

--- a/man/area_lookup.Rd
+++ b/man/area_lookup.Rd
@@ -4,11 +4,13 @@
 \name{area_lookup}
 \alias{area_lookup}
 \title{Codes and names of Scottish geographical and administrative areas.}
-\format{A \code{\link[tibble]{tibble}} with 2 variables and over 17,000 rows:
+\format{
+A \code{\link[tibble]{tibble}} with 2 variables and over 17,000 rows:
 \describe{
   \item{geo_code}{Standard geography code - 9 characters}
   \item{area_name}{Name of the area the code represents}
-}}
+}
+}
 \source{
 \url{https://statistics.gov.scot/}
 }

--- a/man/chi_pad.Rd
+++ b/man/chi_pad.Rd
@@ -12,7 +12,7 @@ chi_pad(x)
 \description{
 \code{chi_pad} takes a nine-digit CHI number with
 \code{character} class and prefixes it with a zero. Any values provided
-which are not nine characters in length remain unchanged.
+which are not a string comprised of nine numeric digits remain unchanged.
 }
 \details{
 The Community Health Index (CHI) is a register of all patients in

--- a/tests/testthat/test-chi.R
+++ b/tests/testthat/test-chi.R
@@ -113,3 +113,9 @@ test_that("Vector entry works in chi_pad", {
   expect_equal(chi_pad(c("12345678", NA, "123456789")),
                c("12345678", NA, "0123456789"))
 })
+
+test_that("chi_pad only pads 9 character strings comprised of numeric digits", {
+  expect_equal(chi_pad("abcdefghi"), "abcdefghi")
+  expect_equal(chi_pad(c("246789532", "jklmnopqr", "123223")),
+               c("0246789532", "jklmnopqr", "123223"))
+})


### PR DESCRIPTION
Hi guys,

This is to close #34. I built it on a newer version of R than PHS has but hopefully that won't change anything for you other than some spacing in a couple of the `.Rd` files and the README.

Let me know if any changes are needed!