### PR TITLE
Fix fin_year to sort output correctly and deal with NAs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,8 @@ Authors@R: c(
     person("Ciara", "Gribben", email = "ciaragribben@nhs.net", role = "aut"),
     person("Chris", "Deans", email = "chrisdeans@nhs.net", role = "aut"),
     person("Jaime", "Villacampa", email = "jaime.villacampa@nhs.net", role = "aut"),
-    person("Graeme", "Gowans", email = "graeme.gowans@nhs.net", role = "aut")
+    person("Graeme", "Gowans", email = "graeme.gowans@nhs.net", role = "aut"),
+    person("Alice", "Byers", email = "alice.byers@nhs.net", role = "ctb")
     )
 Description: Bespoke functions for commonly undertaken analytical tasks in Public Health Scotland.
 License: GPL (>= 2)
@@ -34,4 +35,4 @@ Suggests:
     testthat (>= 2.0.0)
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0

--- a/R/fin_year.R
+++ b/R/fin_year.R
@@ -27,16 +27,23 @@ fin_year <- function(date) {
   # a vector of unique elements from the input, convert those to financial year
   # and then match them back on to the original input. This vastly improves
   # performance for large inputs.
-  tibble::tibble(dates = unique(date)) %>%
-    dplyr::mutate(fin_year = paste0(ifelse(lubridate::month(.data$dates) >= 4,
-                                           lubridate::year(.data$dates),
-                                           lubridate::year(.data$dates) - 1),
-                                    "/",
-                                    substr(
-                                      ifelse(lubridate::month(.data$dates) >= 4,
-                                             lubridate::year(.data$dates) + 1,
-                                             lubridate::year(.data$dates)),
-                                      3, 4))) %>%
-    dplyr::right_join(tibble::tibble(dates = date), by = "dates") %>%
-    dplyr::pull(fin_year)
+
+  x <- tibble::tibble(dates = unique(date)) %>%
+    dplyr::mutate(fyear = paste0(ifelse(lubridate::month(.data$dates) >= 4,
+                                        lubridate::year(.data$dates),
+                                        lubridate::year(.data$dates) - 1),
+                                 "/",
+                                 substr(
+                                   ifelse(lubridate::month(.data$dates) >= 4,
+                                          lubridate::year(.data$dates) + 1,
+                                          lubridate::year(.data$dates)),
+                                   3, 4)),
+                  fyear = ifelse(is.na(.data$dates),
+                                 NA_character_,
+                                 .data$fyear))
+
+  tibble::tibble(dates = date) %>%
+    dplyr::left_join(x, by = "dates") %>%
+    dplyr::pull(.data$fyear)
+
 }

--- a/tests/testthat/test-fin_year.R
+++ b/tests/testthat/test-fin_year.R
@@ -21,3 +21,7 @@ test_that("Non-date formats produce an error", {
   expect_error(fin_year(as.factor("28-Oct-2019")))
 })
 
+test_that("NAs are handled correctly", {
+  expect_equal(fin_year(c(lubridate::dmy(05012020), NA)), c("2019/20", NA))
+})
+


### PR DESCRIPTION
Hi guys,
This is to close #36  - fin_year now uses `left_join()` as behaviour of `right_join()` has changed in dplyr 1.0.0. Also improved handling of NAs. 

Let me know if any other changes needed.
Thanks,
Alice